### PR TITLE
Update navigation.yml

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -69,6 +69,10 @@ primary:
       - text: User Forum
         href: https://try.discourse.org/
         external: true
+      - text: Request Project Storage
+        href: /support/request-storage
+      - text: Request Software
+        href: /support/request-software
   - text: About
     links:
       - text: Overview

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -37,14 +37,12 @@ primary:
 
   - text: Education
     links:
-      - text: Tutorials
+      - text: Science Tutorials
         href: /education/tutorials/
-      - text: Workshops
+      - text: Past Workshops
         href: /education/workshops/
       - text: Videos
         href: /education/video/
-      - text: Plan a training
-        href: /education/plan-training/
   - text: Use Cases
     links:
       - text: Research Leader
@@ -81,9 +79,18 @@ primary:
         href: /about/networking
       - text: Organization
         href: /about/organization
+      - text: Working Groups
+        href: /about/working-groups
       - text: People
         href: /about/people
-
+      - text: Contact
+        href: /about/contact
+  - text: Opportunities
+    links:
+      - text: Plan a Workshop
+        href: /education/plan-workshop/
+      - text: Postdocs
+        href: /about/postdocs
 # secondary:
 #   - text: Documentation
 #     href: /docs/


### PR DESCRIPTION
update Education link names: Science Tutorials, Past Workshops;
add About pages: Working Groups, Contact (for all contacts in one place: project manager, website, newsletter, VRSC);
add Opportunities drop down with links to Plan a Workshop (moved from Education) and page for postdoc positions (ORISE)