### PR TITLE
moved all the announcements about downtime to a new downtime page. No…

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -16,6 +16,8 @@ primary:
     href: /signup/
   - text: News
     links:
+      - text: System Downtime
+        href: /downtime/
       - text: Announcements
         href: /announcements/
       - text: User Stories

--- a/_posts/2019-11-25-Coyle.md
+++ b/_posts/2019-11-25-Coyle.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Reminder - Ceres Downtime in One Week, Dec 2-6
-categories: [Announcements]
+categories: [Downtime]
 excerpt: Ceres downtime is scheduled for  Monday, December 2 – Friday, December 6
 ---
 ### By: Jim Coyle, VRSC  |  11-25-2019 

--- a/_posts/2020-02-03-maintence.md
+++ b/_posts/2020-02-03-maintence.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Reminder - Ceres Downtime February 17
-categories: [Announcements]
+categories: [Downtime]
 excerpt: Ceres downtime is scheduled for Presidents' day, Monday, February 17th
 ---
 ### By: David Orman, VRSC  | 02-03-2020

--- a/_posts/2020-02-27-Joiner.md
+++ b/_posts/2020-02-27-Joiner.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Clay Center Scheduled Outage March 2
-categories: [Announcements]
+categories: [Downtime]
 excerpt: Connectivity from Clay Center to SCINet assets will be disrupted Monday, March 2, 10:30am – 1:00pm EST.
 ---
 ### By: Jay Joiner  |  02-27-2020 

--- a/_posts/2020-03-05-Joiner.md
+++ b/_posts/2020-03-05-Joiner.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Ft Collins Scheduled Outage March 12
-categories: [Announcements]
+categories: [Downtime]
 excerpt: Connectivity from Ft Collins to SCINet assets will be disrupted Thursday, March 12, 10am – noon Mountain Time.
 ---
 ### By: Jay Joiner  |  03-05-2020 

--- a/_posts/2020-03-17-Joiner.md
+++ b/_posts/2020-03-17-Joiner.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Ft Collins Scheduled Outage March 19
-categories: [Announcements]
+categories: [Downtime]
 excerpt: Connectivity from Ft Collins to SCINet assets will be disrupted Thursday, March 19, 9:30 – 11:30am Mountain Time.
 ---
 ### By: Jay Joiner  |  03-17-2020 

--- a/_posts/2020-04-15-Joiner.md
+++ b/_posts/2020-04-15-Joiner.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: April 17-19 Planned Power Outage to Affect Beltsville, Fargo, University Park, All AWS Users
-categories: [Announcements]
+categories: [Downtime]
 excerpt: On Friday, 17 April 2020 starting at 9:00pm ET SCINet equipment at the National Agricultural Library will be powered down in advance of...
 ---
 ### By: Jay Joiner  |  04-15-2020 

--- a/pages/announcements.md
+++ b/pages/announcements.md
@@ -4,21 +4,8 @@ layout: categories
 permalink: /announcements/
 ---
 
-## SCINet Scheduled Outages
 
-The table below lists information about planned SCINet outages. See the SCINet VRSC Basecamp (must have SCINet account to access) [schedule (calendar)](https://3.basecamp.com/3625179/buckets/5538276/schedules/764923017) and [message board](https://3.basecamp.com/3625179/buckets/5538276/message_boards/764923015) for communications about emergency outages.
+Various announcements from the Virtual Research Support Core to SCINet users. See also the [SCINet VRSC Basecamp message board](https://3.basecamp.com/3625179/buckets/5538276/message_boards/764923015) (must have a SCINet account to access). 
 
-
-| Outage Date | System | Affected Locations | Reason |
-|---|---|---|---|
-| 12/2/2019-12/6/2019 | Ceres | All (Ceres offline) | upgrades/expansion |
-| 2/17/2020 | Ceres | All (Ceres offline) | maintenance |
-| 3/2/2020 | SCINet | Clay Center | router replacement |
-| 3/12/2020 | SCINet | Ft Collins | router replacement |
-| 3/19/2020 | SCINet | Ft Collins | router migration |
-| 4/17/2020-4/19/2020 | SCINet & AWS | Beltsville, Fargo, University Park, All AWS Users | planned power outage |
-| 6/16/2020-6/17/2020 | Ceres | All (Ceres offline) | maintenance |
-| 10/12/2020 | Ceres | All (Ceres offline) | maintenance |    
-
-
-**Further detail for each outage will be posted in advance of the outage date in the announcements below.**
+For system downtime information see the [System Downtime page](/downtime/) for planned downtime and [SCINet VRSC Basecamp message board](https://3.basecamp.com/3625179/buckets/5538276/message_boards/764923015) (must have a SCINet account to access) about unplanned outages/system status.
+ 

--- a/pages/downtime.md
+++ b/pages/downtime.md
@@ -1,0 +1,25 @@
+---
+title: Downtime
+layout: categories
+permalink: /downtime/
+---
+
+
+## SCINet Scheduled Outages
+
+The table below lists information about planned SCINet outages. See the SCINet VRSC Basecamp (must have SCINet account to access) [schedule (calendar)](https://3.basecamp.com/3625179/buckets/5538276/schedules/764923017) and [message board](https://3.basecamp.com/3625179/buckets/5538276/message_boards/764923015) for communications about emergency outages.
+
+
+| Outage Date | System | Affected Locations | Reason |
+|---|---|---|---|
+| 12/2/2019-12/6/2019 | Ceres | All (Ceres offline) | upgrades/expansion |
+| 2/17/2020 | Ceres | All (Ceres offline) | maintenance |
+| 3/2/2020 | SCINet | Clay Center | router replacement |
+| 3/12/2020 | SCINet | Ft Collins | router replacement |
+| 3/19/2020 | SCINet | Ft Collins | router migration |
+| 4/17/2020-4/19/2020 | SCINet & AWS | Beltsville, Fargo, University Park, All AWS Users | planned power outage |
+| 6/16/2020-6/17/2020 | Ceres | All (Ceres offline) | maintenance |
+| 10/12/2020 | Ceres | All (Ceres offline) | maintenance |    
+
+
+**Further detail for each outage will be posted in advance of the outage date in the announcements below.**


### PR DESCRIPTION
…w the announcements page can be used for other VRSC announcements that aren't about downtime. Posts to the announcements page should still contain the category Announcements in the front matter. Posts about downtime should contain the category Downtime.