### PR TITLE
Moving site build and deploy to GitHub Actions

### DIFF
--- a/.github/workflows/build_and_deploy_to_gh-pages.yml
+++ b/.github/workflows/build_and_deploy_to_gh-pages.yml
@@ -9,7 +9,7 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
+      - name: Checkout
         uses: actions/checkout@v2
 
       # Use GitHub Actions' cache to shorten build times and decrease load on
@@ -21,7 +21,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gems-
 
-      - name: build and deploy
+      - name: Build site and deploy to gh-pages branch
         uses: helaili/jekyll-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy_to_gh-pages.yml
+++ b/.github/workflows/deploy_to_gh-pages.yml
@@ -1,0 +1,29 @@
+name: Build and Deploy
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      # Use GitHub Actions' cache to shorten build times and decrease load on
+      # servers.
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
+      - name: build and deploy
+        uses: helaili/jekyll-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          target_branch: 'gh-pages'
+


### PR DESCRIPTION
Created a new GitHub Actions workflow for building and deploying the site, moving away from TravisCI.